### PR TITLE
Fix for SIGSEGV when bad payload comes in

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -597,6 +597,9 @@ static int m_se(struct aec_stream *strm)
 
         while (i < strm->block_size) {
             m = direct_get_fs(strm);
+            if (2 * m + 1 > sizeof(state->se_table)) {
+                return M_ERROR;
+            }
             d1 = m - state->se_table[2 * m + 1];
 
             if ((i & 1) == 0) {


### PR DESCRIPTION
For some reason the attached payload crashes the library with a SIGSEGV. The fix solves the issue by just returning error.

Test code:
```c
#include <szlib.h>
#include <stdio.h>

int main() {
  int inputLength = 731;
  char output[5424];
  char input[731];

  SZ_com_t params;

  FILE *f = fopen("input.bin", "rb");
  fread(input, inputLength, 1, f);
  fclose(f);

  //  {options_mask = 177, bits_per_pixel = 8, pixels_per_block = 32, pixels_per_scanline = 5424}
  params.options_mask = 177;
  params.bits_per_pixel = 8;
  params.pixels_per_block = 32;
  params.pixels_per_scanline = 5424;

  size_t destLen = 5424;
  int status = SZ_BufftoBuffDecompress(output, &destLen, input, inputLength, &params);
  f = fopen("raw.dec", "wb");
  fwrite(output, destLen, 1, f);
  fclose(f);

  return status != AEC_OK ? status : destLen;
}
```

[input.zip](https://github.com/erget/libaec/files/2753419/input.zip)

